### PR TITLE
only push null if field is not required

### DIFF
--- a/src/interface/Attributes.ts
+++ b/src/interface/Attributes.ts
@@ -101,7 +101,9 @@ export default class Attributes {
         case 'enumeration':
             const hasDefault = 'default' in attr;
             const enums = attr.enum.map((en: string) => `"${en}"`);
-            enums.push('null');
+            if (attr.required !== true) {
+                enums.push('null');
+            }
             const typeString = enums.join(' | ');
             str += typeString;
             break;


### PR DESCRIPTION
When using an field of the type "enumeration" an additional `null` gets pushed to the array options regardless if the field is required or not.

To ensure that null only gets pushed when the field is not required, an additional if-check is required.